### PR TITLE
netd: Fix UID routing / netlink for wlan0 (Legacy)

### DIFF
--- a/server/RouteController.cpp
+++ b/server/RouteController.cpp
@@ -73,6 +73,12 @@ const char* const ROUTE_TABLE_NAME_LEGACY_SYSTEM  = "legacy_system";
 const char* const ROUTE_TABLE_NAME_LOCAL = "local";
 const char* const ROUTE_TABLE_NAME_MAIN  = "main";
 
+// TODO: These values aren't defined by the Linux kernel, because legacy UID routing (as used in N
+// and below) was not upstreamed. Now that the UID routing code is upstream, we should remove these
+// and rely on the kernel header values.
+const uint16_t FRA_UID_START = 18;
+const uint16_t FRA_UID_END   = 19;
+
 // These values are upstream, but not yet in our headers.
 // TODO: delete these definitions when updating the headers.
 const uint16_t FRA_UID_RANGE = 20;
@@ -115,6 +121,8 @@ rtattr FRATTR_PRIORITY  = { U16_RTA_LENGTH(sizeof(uint32_t)),           FRA_PRIO
 rtattr FRATTR_TABLE     = { U16_RTA_LENGTH(sizeof(uint32_t)),           FRA_TABLE };
 rtattr FRATTR_FWMARK    = { U16_RTA_LENGTH(sizeof(uint32_t)),           FRA_FWMARK };
 rtattr FRATTR_FWMASK    = { U16_RTA_LENGTH(sizeof(uint32_t)),           FRA_FWMASK };
+rtattr FRATTR_UID_START = { U16_RTA_LENGTH(sizeof(uid_t)),              FRA_UID_START };
+rtattr FRATTR_UID_END   = { U16_RTA_LENGTH(sizeof(uid_t)),              FRA_UID_END };
 rtattr FRATTR_UID_RANGE = { U16_RTA_LENGTH(sizeof(fib_rule_uid_range)), FRA_UID_RANGE };
 
 rtattr RTATTR_TABLE     = { U16_RTA_LENGTH(sizeof(uint32_t)),           RTA_TABLE };
@@ -318,6 +326,18 @@ WARN_UNUSED_RESULT int modifyIpRule(uint16_t action, uint32_t priority, uint8_t 
         { &fwmark,           mask ? sizeof(fwmark) : 0 },
         { &FRATTR_FWMASK,    mask ? sizeof(FRATTR_FWMASK) : 0 },
         { &mask,             mask ? sizeof(mask) : 0 },
+        // Rules that contain both legacy and new UID routing attributes will work on old kernels,
+        // which will simply ignore the FRA_UID_RANGE attribute since it is larger than their
+        // FRA_MAX. They will also work on kernels that are not too new:
+        // - FRA_UID_START clashes with FRA_PAD in 4.7, but that shouldn't be a problem because
+        //   FRA_PAD has no validation.
+        // - FRA_UID_END clashes with FRA_L3MDEV in 4.8 and above, and will cause an error because
+        //   FRA_L3MDEV has a maximum length of 1.
+        // TODO: delete the legacy UID routing code before running it on 4.8 or above.
+        { &FRATTR_UID_START, isUidRule ? sizeof(FRATTR_UID_START) : 0 },
+        { &uidStart,         isUidRule ? sizeof(uidStart) : 0 },
+        { &FRATTR_UID_END,   isUidRule ? sizeof(FRATTR_UID_END) : 0 },
+        { &uidEnd,           isUidRule ? sizeof(uidEnd) : 0 },
         { &FRATTR_UID_RANGE, isUidRule ? sizeof(FRATTR_UID_RANGE) : 0 },
         { &uidRange,         isUidRule ? sizeof(uidRange) : 0 },
         { &fraIifName,       iif != IIF_NONE ? sizeof(fraIifName) : 0 },

--- a/server/RouteController.cpp
+++ b/server/RouteController.cpp
@@ -73,19 +73,15 @@ const char* const ROUTE_TABLE_NAME_LEGACY_SYSTEM  = "legacy_system";
 const char* const ROUTE_TABLE_NAME_LOCAL = "local";
 const char* const ROUTE_TABLE_NAME_MAIN  = "main";
 
-// TODO: These values aren't defined by the Linux kernel, because legacy UID routing (as used in N
-// and below) was not upstreamed. Now that the UID routing code is upstream, we should remove these
-// and rely on the kernel header values.
+// TODO: These values aren't defined by the Linux kernel, because our UID routing changes are not
+// upstream (yet?), so we can't just pick them up from kernel headers. When (if?) the changes make
+// it upstream, we'll remove this and rely on the kernel header values. For now, add a static assert
+// that will warn us if upstream has given these values some other meaning.
 const uint16_t FRA_UID_START = 18;
 const uint16_t FRA_UID_END   = 19;
-
-// These values are upstream, but not yet in our headers.
-// TODO: delete these definitions when updating the headers.
-const uint16_t FRA_UID_RANGE = 20;
-struct fib_rule_uid_range {
-        __u32           start;
-        __u32           end;
-};
+static_assert(FRA_UID_START > FRA_MAX,
+             "Android-specific FRA_UID_{START,END} values also assigned in Linux uapi. "
+             "Check that these values match what the kernel does and then update this assertion.");
 
 const uint16_t NETLINK_REQUEST_FLAGS = NLM_F_REQUEST | NLM_F_ACK;
 const uint16_t NETLINK_CREATE_REQUEST_FLAGS = NETLINK_REQUEST_FLAGS | NLM_F_CREATE | NLM_F_EXCL;
@@ -117,16 +113,15 @@ constexpr uint16_t U16_RTA_LENGTH(uint16_t x) {
 
 // These are practically const, but can't be declared so, because they are used to initialize
 // non-const pointers ("void* iov_base") in iovec arrays.
-rtattr FRATTR_PRIORITY  = { U16_RTA_LENGTH(sizeof(uint32_t)),           FRA_PRIORITY };
-rtattr FRATTR_TABLE     = { U16_RTA_LENGTH(sizeof(uint32_t)),           FRA_TABLE };
-rtattr FRATTR_FWMARK    = { U16_RTA_LENGTH(sizeof(uint32_t)),           FRA_FWMARK };
-rtattr FRATTR_FWMASK    = { U16_RTA_LENGTH(sizeof(uint32_t)),           FRA_FWMASK };
-rtattr FRATTR_UID_START = { U16_RTA_LENGTH(sizeof(uid_t)),              FRA_UID_START };
-rtattr FRATTR_UID_END   = { U16_RTA_LENGTH(sizeof(uid_t)),              FRA_UID_END };
-rtattr FRATTR_UID_RANGE = { U16_RTA_LENGTH(sizeof(fib_rule_uid_range)), FRA_UID_RANGE };
+rtattr FRATTR_PRIORITY  = { U16_RTA_LENGTH(sizeof(uint32_t)), FRA_PRIORITY };
+rtattr FRATTR_TABLE     = { U16_RTA_LENGTH(sizeof(uint32_t)), FRA_TABLE };
+rtattr FRATTR_FWMARK    = { U16_RTA_LENGTH(sizeof(uint32_t)), FRA_FWMARK };
+rtattr FRATTR_FWMASK    = { U16_RTA_LENGTH(sizeof(uint32_t)), FRA_FWMASK };
+rtattr FRATTR_UID_START = { U16_RTA_LENGTH(sizeof(uid_t)),    FRA_UID_START };
+rtattr FRATTR_UID_END   = { U16_RTA_LENGTH(sizeof(uid_t)),    FRA_UID_END };
 
-rtattr RTATTR_TABLE     = { U16_RTA_LENGTH(sizeof(uint32_t)),           RTA_TABLE };
-rtattr RTATTR_OIF       = { U16_RTA_LENGTH(sizeof(uint32_t)),           RTA_OIF };
+rtattr RTATTR_TABLE     = { U16_RTA_LENGTH(sizeof(uint32_t)), RTA_TABLE };
+rtattr RTATTR_OIF       = { U16_RTA_LENGTH(sizeof(uint32_t)), RTA_OIF };
 
 uint8_t PADDING_BUFFER[RTA_ALIGNTO] = {0, 0, 0, 0};
 
@@ -313,7 +308,6 @@ WARN_UNUSED_RESULT int modifyIpRule(uint16_t action, uint32_t priority, uint8_t 
 
     rtattr fraIifName = { U16_RTA_LENGTH(iifLength), FRA_IIFNAME };
     rtattr fraOifName = { U16_RTA_LENGTH(oifLength), FRA_OIFNAME };
-    struct fib_rule_uid_range uidRange = { uidStart, uidEnd };
 
     iovec iov[] = {
         { NULL,              0 },
@@ -326,20 +320,10 @@ WARN_UNUSED_RESULT int modifyIpRule(uint16_t action, uint32_t priority, uint8_t 
         { &fwmark,           mask ? sizeof(fwmark) : 0 },
         { &FRATTR_FWMASK,    mask ? sizeof(FRATTR_FWMASK) : 0 },
         { &mask,             mask ? sizeof(mask) : 0 },
-        // Rules that contain both legacy and new UID routing attributes will work on old kernels,
-        // which will simply ignore the FRA_UID_RANGE attribute since it is larger than their
-        // FRA_MAX. They will also work on kernels that are not too new:
-        // - FRA_UID_START clashes with FRA_PAD in 4.7, but that shouldn't be a problem because
-        //   FRA_PAD has no validation.
-        // - FRA_UID_END clashes with FRA_L3MDEV in 4.8 and above, and will cause an error because
-        //   FRA_L3MDEV has a maximum length of 1.
-        // TODO: delete the legacy UID routing code before running it on 4.8 or above.
         { &FRATTR_UID_START, isUidRule ? sizeof(FRATTR_UID_START) : 0 },
         { &uidStart,         isUidRule ? sizeof(uidStart) : 0 },
         { &FRATTR_UID_END,   isUidRule ? sizeof(FRATTR_UID_END) : 0 },
         { &uidEnd,           isUidRule ? sizeof(uidEnd) : 0 },
-        { &FRATTR_UID_RANGE, isUidRule ? sizeof(FRATTR_UID_RANGE) : 0 },
-        { &uidRange,         isUidRule ? sizeof(uidRange) : 0 },
         { &fraIifName,       iif != IIF_NONE ? sizeof(fraIifName) : 0 },
         { iifName,           iifLength },
         { PADDING_BUFFER,    iifPadding },

--- a/server/SoftapController.cpp
+++ b/server/SoftapController.cpp
@@ -153,8 +153,8 @@ void *SoftapController::threadStart(void *obj){
 }
 #endif
 
-int SoftapController::startSoftap(bool global_ctrl_iface = false, SocketClient *socketClient = NULL,
-    const char *ifname = NULL) {
+int SoftapController::startSoftap(bool global_ctrl_iface, SocketClient *socketClient,
+    const char *ifname) {
     pid_t pid = 1;
     DIR *dir = NULL;
     int ret;

--- a/server/SoftapController.h
+++ b/server/SoftapController.h
@@ -35,7 +35,7 @@ public:
     SoftapController();
     virtual ~SoftapController();
 
-    int startSoftap(bool global_ctrl_iface, SocketClient *socketClient, const char *iface);
+    int startSoftap(bool global_ctrl_iface = false, SocketClient *socketClient = NULL, const char *iface = NULL);
     int stopSoftap();
     bool isSoftapStarted();
     int setSoftap(int argc, char *argv[]);


### PR DESCRIPTION
Needed for most 3.4 kernels (I Guess)
Goes with Revert "Use new-style UID routing."
- Apparently, the latest AOSP-CAF tag requires the kernel to be compiled
  with CONFIG_ARPD=y
- I haven't deciphered the exact reason why it's needed because on other
  AOSP / LineageOS, we can dump ARP tables without CONFIG_ARPD=y.
- The new UID style routing isn't compatible with older phones running
  3.4 kernels and hence requires additional ported TCP / IP stack
  similar what's done in Bullhead / Sailfish (From Android O).